### PR TITLE
Bugfix/markdown dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Authors@R: c(
         person("Simon", "Crouch", email="simon.crouch@york.ac.uk", role='aut'),
         person("Stephanie", "Lax", email="stephanie.lax@york.ac.uk", role='aut')
         )
-Description: Estimates disease prevalence for a given index date, using existing
-    registry data extended with Monte Carlo simulations.
+Description: Estimates disease prevalence for a given index date using existing
+    registry data extended with Monte Carlo simulations following the method of Crouch et al (2014) <doi: 10.1016/j.canep.2014.02.005>.
 LazyData: true
 License: GPL-2
 Depends:
@@ -23,7 +23,7 @@ Imports:
     lubridate,
     magrittr,
     tidyr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests:
     flexsurv,
     flexsurvcure,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rprev
 Type: Package
 Title: Estimating Disease Prevalence from Registry Data
 Version: 1.0.5
-Date: 2021-04-16
+Date: 2021-04-30
 Authors@R: c(
         person("Stuart", "Lacy", email="stuart.lacy@york.ac.uk", role=c('cre', 'aut')),
         person("Simon", "Crouch", email="simon.crouch@york.ac.uk", role='aut'),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rprev
 Type: Package
 Title: Estimating Disease Prevalence from Registry Data
-Version: 1.0.4
-Date: 2020-03-19
+Version: 1.0.5
+Date: 2021-04-16
 Authors@R: c(
         person("Stuart", "Lacy", email="stuart.lacy@york.ac.uk", role=c('cre', 'aut')),
         person("Simon", "Crouch", email="simon.crouch@york.ac.uk", role='aut'),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Suggests:
     flexsurv,
     flexsurvcure,
     knitr,
+    rmarkdown,
     rms,
     testthat,
     covr

--- a/R/data.R
+++ b/R/data.R
@@ -2,7 +2,7 @@
 #'
 #' A dataset containing daily population survival rates for individuals up to 100 years old,
 #' from the UK population, derived from the 2009 mortality rates found at:
-#' \url{http://www.ons.gov.uk/ons/taxonomy/index.html?nscl=Life+Tables#tab-data-tables},
+#' \url{https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/lifeexpectancies/datasets/nationallifetablesunitedkingdomreferencetables},
 #' Adapted from public sector information licensed under the Open Government Licence v3.0.
 #' Data were relabelled according to the mean year of the three-year birth window.
 #' It is stored as a \code{data.table} for efficient access.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Monte Carlo simulation techniques are used to simulate incident cases in years f
 
 Prevalence arises from two independent stochastic processes: disease incidence and survival.
 Default models are provided that model incidence as a homogeneous Poisson process and survival as a standard parameteric distribution, although both of these models can be user specified for further control.
-See the *user_guide* vignette for more details about the implementation, and the original publication for details of the algorithm, available at [http://www.ncbi.nlm.nih.gov/pubmed/24656754](http://www.ncbi.nlm.nih.gov/pubmed/24656754).
+See the *user_guide* vignette for more details about the implementation, and the original publication for details of the algorithm, available at [https://pubmed.ncbi.nlm.nih.gov/24656754/](https://pubmed.ncbi.nlm.nih.gov/24656754/).
 
 ## Installation
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,7 @@
+## Resubmission 2
+
+Updated URL with https that had missed out in previous submission.
+
 ## Resubmission
 
 Updated URLs with https and corrected out-of-date links. 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,20 @@
+## Resubmission
+
+Updated URLs with https and corrected out-of-date links. 
+Added DOI to package description.
+
 ## Release summary
 
-Made changes to account for the upcoming stringsAsFactors = FALSE default argument to data.frame() in R 4.0 so that the package is backwards compatible.
+Explicitly declared `rmarkdown` dependency in SUGGESTS for building the vignette.
 
 ## Test environments
 
-* local Manjaro Linux install, R 3.6.3
-* Win-builder R 3.6.3
+* local Manjaro Linux install, R 4.0.5
 * Win-builder r-devel
 
 ## R CMD check results
 
-There were no ERRORS, WARNINGS, or NOTES.
+There were no ERRORS or WARNINGS, and the only NOTE refers to possible mis-spelling of the words 'et' and 'al' in the DESCRIPTION.
 
 ## Downstream dependencies
 

--- a/man/UKmortality.Rd
+++ b/man/UKmortality.Rd
@@ -4,19 +4,21 @@
 \name{UKmortality}
 \alias{UKmortality}
 \title{General population survival data.}
-\format{A data frame with 109575 rows and 3 columns:
+\format{
+A data frame with 109575 rows and 3 columns:
 \describe{
  \item{age}{age in days}
  \item{sex}{string, either 'M' or 'F'}
  \item{surv}{survival probability , estimated as the cumulative product of (1 - mortality rate)}
-}}
+}
+}
 \usage{
 UKmortality
 }
 \description{
 A dataset containing daily population survival rates for individuals up to 100 years old,
 from the UK population, derived from the 2009 mortality rates found at:
-\url{http://www.ons.gov.uk/ons/taxonomy/index.html?nscl=Life+Tables#tab-data-tables},
+\url{https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/lifeexpectancies/datasets/nationallifetablesunitedkingdomreferencetables},
 Adapted from public sector information licensed under the Open Government Licence v3.0.
 Data were relabelled according to the mean year of the three-year birth window.
 It is stored as a \code{data.table} for efficient access.

--- a/man/prevsim.Rd
+++ b/man/prevsim.Rd
@@ -4,7 +4,8 @@
 \name{prevsim}
 \alias{prevsim}
 \title{Simulated patient dataset.}
-\format{A data frame with 1000 rows and 6 columns:
+\format{
+A data frame with 1000 rows and 6 columns:
 \describe{
  \item{time}{time between date of diagnosis and death or censorship in days}
  \item{status}{event marker; 1 if patient is deceased and 0 if alive or censored}
@@ -12,7 +13,8 @@
  \item{sex}{string with values 'M' and 'F'}
  \item{entrydate}{date of entry into the registry in YYYY-MM-DD format}
  \item{eventdate}{date of death or censorship in YYYY-MM-DD format}
-}}
+}
+}
 \usage{
 prevsim
 }

--- a/vignettes/bibliography.bib
+++ b/vignettes/bibliography.bib
@@ -7,7 +7,7 @@
   pages={193--199},
   year={2014},
   publisher={Elsevier},
-  url={http://www.ncbi.nlm.nih.gov/pubmed/24656754}
+  url={https://pubmed.ncbi.nlm.nih.gov/24656754/}
 }
 
 @misc{ons,


### PR DESCRIPTION
`rmarkdown` now needs to be explicitly marked as a dependency in the Suggests section of `DESCRIPTION`. This release makes this change as well as a few minor documentation changes.